### PR TITLE
Fixes "/list" message if only one player online

### DIFF
--- a/src/main/java/com/helion3/bedrock/commands/ListCommand.java
+++ b/src/main/java/com/helion3/bedrock/commands/ListCommand.java
@@ -42,10 +42,17 @@ public class ListCommand {
             .description(Text.of("List online players."))
             .executor((source, args) -> {
                 Collection<Player> players = Bedrock.getGame().getServer().getOnlinePlayers();
-
-                source.sendMessage(Format.heading("There are ",
-                    TextColors.AQUA, players.size(), TextColors.GOLD, " players online!"));
-
+                int playerAmount = players.size();
+                
+                if (playerAmount == 1){
+                    source.sendMessage(Format.heading("There is ",
+                        TextColors.AQUA, playerAmount, TextColors.GOLD, " player online!"));
+                }
+                else {
+                    source.sendMessage(Format.heading("There are ",
+                        TextColors.AQUA, playerAmount, TextColors.GOLD, " players online!"));
+                }
+                
                 ArrayList<String> names = new ArrayList<>();
                 for (Player player : players) {
                     names.add(player.getName());


### PR DESCRIPTION
Right now if there is only one player online, it still says "There are 1 players online!" which does not make grammatical sense, so this commit changes it to "There is 1 player online!". To do this I created a new int variable called playerAmount, so I would not have to call `players.size()` three times.